### PR TITLE
Add video cropping helper

### DIFF
--- a/build-exe.bat
+++ b/build-exe.bat
@@ -1,0 +1,8 @@
+@echo off
+setlocal
+
+:: Build the Windows executable
+
+yarn pack-win
+
+endlocal

--- a/install-deps.bat
+++ b/install-deps.bat
@@ -1,0 +1,10 @@
+@echo off
+setlocal
+
+:: Install Node dependencies
+yarn install
+
+:: Download FFmpeg for Windows
+yarn download-ffmpeg-win32-x64
+
+endlocal

--- a/src/main/ffmpeg.ts
+++ b/src/main/ffmpeg.ts
@@ -643,6 +643,25 @@ export function createMediaSourceProcess({ path, videoStreamIndex, audioStreamIn
   return execa(getFfmpegPath(), args, { encoding: 'buffer', buffer: false, stderr: enableLog ? 'inherit' : 'pipe' });
 }
 
+export async function cropVideo({ inPath, outPath, width, height, x, y }: {
+  inPath: string,
+  outPath: string,
+  width: number,
+  height: number,
+  x: number,
+  y: number,
+}) {
+  const args = [
+    '-i', inPath,
+    '-filter:v', `crop=${width}:${height}:${x}:${y}`,
+    '-c:a', 'copy',
+    '-y', outPath,
+  ];
+
+  await runFfmpegProcess(args);
+  return args;
+}
+
 export async function downloadMediaUrl(url: string, outPath: string) {
   // User agent taken from https://techblog.willshouse.com/2012/01/03/most-common-user-agents/
   const userAgent = 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36';

--- a/src/renderer/src/ffmpeg.ts
+++ b/src/renderer/src/ffmpeg.ts
@@ -14,10 +14,10 @@ import { UnsupportedFileError } from '../errors';
 
 const { ffmpeg, fileTypePromise } = window.require('@electron/remote').require('./index.js');
 
-const { renderWaveformPng, mapTimesToSegments, detectSceneChanges, captureFrames, captureFrame, getFfCommandLine, runFfmpegConcat, runFfmpegWithProgress, getDuration, abortFfmpegs, runFfmpeg, runFfprobe, getFfmpegPath, setCustomFfPath } = ffmpeg;
+const { renderWaveformPng, mapTimesToSegments, detectSceneChanges, captureFrames, captureFrame, getFfCommandLine, runFfmpegConcat, runFfmpegWithProgress, getDuration, abortFfmpegs, runFfmpeg, runFfprobe, getFfmpegPath, setCustomFfPath, cropVideo } = ffmpeg;
 
 
-export { renderWaveformPng, mapTimesToSegments, detectSceneChanges, captureFrames, captureFrame, getFfCommandLine, runFfmpegConcat, runFfmpegWithProgress, getDuration, abortFfmpegs, runFfmpeg, getFfmpegPath, setCustomFfPath };
+export { renderWaveformPng, mapTimesToSegments, detectSceneChanges, captureFrames, captureFrame, getFfCommandLine, runFfmpegConcat, runFfmpegWithProgress, getDuration, abortFfmpegs, runFfmpeg, getFfmpegPath, setCustomFfPath, cropVideo };
 
 
 export class RefuseOverwriteError extends Error {

--- a/src/renderer/src/hooks/useFfmpegOperations.ts
+++ b/src/renderer/src/hooks/useFfmpegOperations.ts
@@ -5,7 +5,7 @@ import pMap from 'p-map';
 import invariant from 'tiny-invariant';
 
 import { getSuffixedOutPath, transferTimestamps, getOutFileExtension, getOutDir, deleteDispositionValue, getHtml5ifiedPath, unlinkWithRetry, getFrameDuration, isMac } from '../util';
-import { isCuttingStart, isCuttingEnd, runFfmpegWithProgress, getFfCommandLine, getDuration, createChaptersFromSegments, readFileMeta, getExperimentalArgs, getVideoTimescaleArgs, logStdoutStderr, runFfmpegConcat, RefuseOverwriteError, runFfmpeg } from '../ffmpeg';
+import { isCuttingStart, isCuttingEnd, runFfmpegWithProgress, getFfCommandLine, getDuration, createChaptersFromSegments, readFileMeta, getExperimentalArgs, getVideoTimescaleArgs, logStdoutStderr, runFfmpegConcat, RefuseOverwriteError, runFfmpeg, cropVideo as cropVideoMain } from '../ffmpeg';
 import { getMapStreamsArgs, getStreamIdsToCopy } from '../util/streams';
 import { getSmartCutParams } from '../smartcut';
 import { getGuaranteedSegments, isDurationValid } from '../segments';
@@ -833,6 +833,18 @@ function useFfmpegOperations({ filePath, treatInputFileModifiedTimeAsStart, trea
     return outPath;
   }, [appendFfmpegCommandLog, filePath, treatInputFileModifiedTimeAsStart, treatOutputFileModifiedTimeAsStart]);
 
+  const cropVideo = useCallback(async ({ inPath, outPath, width, height, x, y }: {
+    inPath: string,
+    outPath: string,
+    width: number,
+    height: number,
+    x: number,
+    y: number,
+  }) => {
+    const ffmpegArgs = await cropVideoMain({ inPath, outPath, width, height, x, y });
+    appendFfmpegCommandLog(ffmpegArgs);
+  }, [appendFfmpegCommandLog]);
+
   function getPreferredCodecFormat(stream: LiteFFprobeStream) {
     const map = {
       mp3: { format: 'mp3', ext: 'mp3' },
@@ -977,7 +989,7 @@ function useFfmpegOperations({ filePath, treatInputFileModifiedTimeAsStart, trea
   }, [extractAttachmentStreams, extractNonAttachmentStreams, filePath]);
 
   return {
-    cutMultiple, concatFiles, html5ify, html5ifyDummy, fixInvalidDuration, concatCutSegments, extractStreams, tryDeleteFiles,
+    cutMultiple, concatFiles, html5ify, html5ifyDummy, fixInvalidDuration, concatCutSegments, extractStreams, tryDeleteFiles, cropVideo,
   };
 }
 


### PR DESCRIPTION
## Summary
- add new `cropVideo` helper in the FFmpeg main module
- expose helper via renderer's ffmpeg bridge
- wrap `cropVideo` in renderer hook
- add helper batch scripts to install dependencies and build Windows executable

## Testing
- `npm test` *(fails: vitest not found)*