### PR TITLE
Improve ffmpeg startup failure message

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -7,6 +7,13 @@ There is no installer. The app is just a compressed file that you download from 
 - MacOS: Mount the `dmg` and drag the app into your `Applications` folder.
 - Linux: Y'all know what to do ;)
 
+## Installation troubleshooting
+
+If LosslessCut fails to start and complains that `ffmpeg.exe` cannot be found or executed,
+make sure the app is fully extracted from the downloaded archive. Some anti-virus
+software may block `ffmpeg.exe`. Try whitelisting it or temporarily disabling the
+anti-virus before launching the app.
+
 ## Portable app?
 
 LosslessCut is **not** a portable app. If you install it from the Mac App Store or Microsoft Store, it is somewhat portable because it will be containerized by the operating system, so that when you uninstall the app there will most likely not be many traces of it left. You *can* however customise where settings are stored, see below.

--- a/src/renderer/src/mifi.ts
+++ b/src/renderer/src/mifi.ts
@@ -39,6 +39,19 @@ export async function runStartupCheck({ customFfPath }: { customFfPath: string |
         });
         return;
       }
+
+      const msg = err.message ?? '';
+      if (
+        (!customFfPath && 'code' in err && err.code === 'ENOENT')
+        || msg.includes('is not recognized as an internal or external command')
+      ) {
+        Swal.fire({
+          icon: 'error',
+          title: 'Fatal: ffmpeg.exe missing',
+          text: `ffmpeg.exe could not be found or executed. Verify that LosslessCut is fully extracted and that your anti-virus software isn't blocking it. See the installation notes: https://github.com/mifi/lossless-cut/blob/master/installation.md#installation-troubleshooting`,
+        });
+        return;
+      }
     }
 
     handleError('Fatal: ffmpeg non-functional', err);


### PR DESCRIPTION
## Summary
- show better error when ffmpeg.exe cannot be found or executed
- add installation troubleshooting notes about antivirus and extraction

## Testing
- `yarn test` *(fails: Connect Timeout Error)*