### PR TITLE
Fix doc for Windows extraction

### DIFF
--- a/installation.md
+++ b/installation.md
@@ -4,6 +4,11 @@
 
 There is no installer. The app is just a compressed file that you download from [GitHub](https://github.com/mifi/lossless-cut/releases) and extract. Then you run the executable contained within.
 - Windows: Download the `.7z` file and extract it using [7zip](https://www.7-zip.org/download.html).
+  **Important:** Extract the entire folder to disk before running `LosslessCut.exe`.
+  Do not launch the app directly from PeaZip, 7-Zip File Manager or any other
+  archive viewer. Running it from a temporary extraction location can lead to
+  errors such as `Fatal: ffmpeg non-functional` or `ffmpeg.exe is not recognized
+  as an internal or external command`.
 - MacOS: Mount the `dmg` and drag the app into your `Applications` folder.
 - Linux: Y'all know what to do ;)
 


### PR DESCRIPTION
## Summary
- advise to extract the Windows folder before launching
- mention archive viewer pitfalls in `installation.md`

## Testing
- `yarn test` *(fails: Connect Timeout Error)*