### PR TITLE
Fix 7-Zip naming in docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,7 +127,7 @@ For Linux these are some alternatives:
 If you prefer to download the executables manually, this will of course always be free (see also [supported operating systems](./requirements.md)):
 
 - macOS: [Intel](https://github.com/mifi/lossless-cut/releases/latest/download/LosslessCut-mac-x64.dmg) / [Apple Silicon](https://github.com/mifi/lossless-cut/releases/latest/download/LosslessCut-mac-arm64.dmg) DMG (note that PKG does **not** work)
-- Windows: [7zip](https://github.com/mifi/lossless-cut/releases/latest/download/LosslessCut-win-x64.7z) (Windows 7, 8 and 8.1 is [no longer supported](https://github.com/mifi/lossless-cut/discussions/1476) after [v3.50.0](https://github.com/mifi/lossless-cut/releases/tag/v3.50.0))
+- Windows: [7‑Zip](https://github.com/mifi/lossless-cut/releases/latest/download/LosslessCut-win-x64.7z) (Windows 7, 8 and 8.1 is [no longer supported](https://github.com/mifi/lossless-cut/discussions/1476) after [v3.50.0](https://github.com/mifi/lossless-cut/releases/tag/v3.50.0))
 - Linux: [x64 tar.bz2](https://github.com/mifi/lossless-cut/releases/latest/download/LosslessCut-linux-x64.tar.bz2) / [x64 AppImage](https://github.com/mifi/lossless-cut/releases/latest/download/LosslessCut-linux-x86_64.AppImage) / [arm64 tar.bz2](https://github.com/mifi/lossless-cut/releases/latest/download/LosslessCut-linux-arm64.tar.bz2) / [Raspberry Pi armv7l](https://github.com/mifi/lossless-cut/releases/latest/download/LosslessCut-linux-armv7l.tar.bz2)
 - [More releases](https://github.com/mifi/lossless-cut/releases) - Note that APPX (Windows) and PKG (macOS) do **not** work)
 - [Latest nightly builds 🧪](https://mifi.no/llc/nightly/)

--- a/installation.md
+++ b/installation.md
@@ -3,9 +3,9 @@
 ## There is no installer
 
 There is no installer. The app is just a compressed file that you download from [GitHub](https://github.com/mifi/lossless-cut/releases) and extract. Then you run the executable contained within.
-- Windows: Download the `.7z` file and extract it using [7zip](https://www.7-zip.org/download.html).
+- Windows: Download the `.7z` file and extract it using [7‑Zip](https://www.7-zip.org/download.html).
   **Important:** Extract the entire folder to disk before running `LosslessCut.exe`.
-  Do not launch the app directly from PeaZip, 7-Zip File Manager or any other
+  Do not launch the app directly from PeaZip, 7‑Zip File Manager or any other
   archive viewer. Running it from a temporary extraction location can lead to
   errors such as `Fatal: ffmpeg non-functional` or `ffmpeg.exe is not recognized
   as an internal or external command`.

--- a/issues.md
+++ b/issues.md
@@ -113,7 +113,7 @@ If you have an issue with the Snap or Flatpak version of LosslessCut, try instea
 - Video preview playback slow, stuttering, flickering inside LosslessCut (NVIDIA)
   - See [#922](https://github.com/mifi/lossless-cut/issues/922) [#1904](https://github.com/mifi/lossless-cut/issues/1904) [#1915](https://github.com/mifi/lossless-cut/issues/1915) [#922](https://github.com/mifi/lossless-cut/issues/922) [#2083](https://github.com/mifi/lossless-cut/issues/2083)
 - Why no `.exe`/`.zip`/`.appx` downloads?
-  - I decided to stop distributing exe/zip and instead just [7zip](https://github.com/mifi/lossless-cut/releases/latest/download/LosslessCut-win-x64.7z), due to the [problems](https://github.com/mifi/lossless-cut/issues/1072#issuecomment-1066026323) that the (self-extracting) exe was causing and the large size of `.zip` files. `appx` is unsigned and [**does not work**](https://github.com/mifi/lossless-cut/issues/337).
+  - I decided to stop distributing exe/zip and instead just [7‑Zip](https://github.com/mifi/lossless-cut/releases/latest/download/LosslessCut-win-x64.7z), due to the [problems](https://github.com/mifi/lossless-cut/issues/1072#issuecomment-1066026323) that the (self-extracting) exe was causing and the large size of `.zip` files. `appx` is unsigned and [**does not work**](https://github.com/mifi/lossless-cut/issues/337).
 - I'm getting a `KERNEL32.dll` error
   - It's probably because you're running Windows 7, 8 or 8.1 which is [no longer supported.](https://github.com/mifi/lossless-cut/discussions/1476)
 


### PR DESCRIPTION
## Summary
- use the same naming for 7‑Zip across docs

## Testing
- `npm test` *(fails: vitest not found)*